### PR TITLE
Bump Fedora version to 36

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 An example repository for the portable services walkthrough blog story published here:
 
-http://0pointer.net/blog/walkthrough-for-portable-services.html
+https://0pointer.net/blog/walkthrough-for-portable-services.html

--- a/mkosi.default
+++ b/mkosi.default
@@ -5,7 +5,7 @@
 
 [Distribution]
 Distribution=fedora
-Release=27
+Release=36
 
 [Output]
 Format=raw_btrfs


### PR DESCRIPTION
Interestingly, the image is smaller: 78 MB → 67 MB.